### PR TITLE
Add read permission for nginx to uWSGI socket

### DIFF
--- a/c3po_wsgi.ini
+++ b/c3po_wsgi.ini
@@ -6,7 +6,7 @@ processes = 8
 threads = 8
 
 socket = c3po.sock
-chmod-socket = 660
+chmod-socket = 664
 vacuum = true
 
 die-on-term = true


### PR DESCRIPTION
The webserver didn't have read access to the uWSGI socket (with permissions 660). Change it to 664.