### PR TITLE
Add endpoint to return a randomly shuffled list

### DIFF
--- a/c3po/api/controller/feed_controller.py
+++ b/c3po/api/controller/feed_controller.py
@@ -103,3 +103,18 @@ class FeedUnderrated(Resource):
             abort(403, response)
         else:
             return response, status
+
+
+@feed_ns.route("/random")
+class FeedUnderrated(Resource):
+    @feed_ns.doc("Randomly shuffled songs")
+    @feed_ns.expect(parser)
+    def get(self):
+        args = parser.parse_args()
+        response, status = FeedService.get_random_posts(
+            request.url, args["start"], args["limit"]
+        )
+        if status != 200:
+            abort(403, response)
+        else:
+            return response, status

--- a/c3po/api/controller/feed_controller.py
+++ b/c3po/api/controller/feed_controller.py
@@ -106,7 +106,7 @@ class FeedUnderrated(Resource):
 
 
 @feed_ns.route("/random")
-class FeedUnderrated(Resource):
+class FeedRandom(Resource):
     @feed_ns.doc("Randomly shuffled songs")
     @feed_ns.expect(parser)
     def get(self):


### PR DESCRIPTION
Add an endpoint `/random` that returns a random shuffled list of posts. It uses the SQLAlchemy `func.random()` function to fetch a random set of posts from the DB

Adds feature requested in #80  