### PR TITLE
[WIP] Setup CodeDeploy for CI/CD

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,55 @@
+name: Deploy C-3PO to Amazon ECS
+
+on:
+  workflow_run:
+    workflows: [ "Build and Test C-3PO" ]
+    branches: [ master ]
+    types:
+      - completed
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-south-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build, tag, and push image to Amazon ECR
+        id: build-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: c3po
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+
+      - name: Fill in the new image ID in the Amazon ECS task definition
+        id: task-def
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: deploy/c3po-taskdef.json
+          container-name: c3po
+          image: ${{ steps.build-image.outputs.image }}
+
+      - name: Deploy Amazon ECS task definition
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        with:
+          task-definition: ${{ steps.task-def.outputs.task-definition }}
+          service: c3po
+          cluster: lttkgp
+          wait-for-service-stability: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,7 @@ jobs:
         uses: aws-actions/amazon-ecs-render-task-definition@v1
         with:
           task-definition: deploy/c3po-taskdef.json
-          container-name: c3po
+          container-name: c3po-container
           image: ${{ steps.build-image.outputs.image }}
 
       - name: Deploy Amazon ECS task definition

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,11 +1,16 @@
 name: Deploy C-3PO to Amazon ECS
 
+# Temporary code. To be removed
 on:
-  workflow_run:
-    workflows: [ "Build and Test C-3PO" ]
-    branches: [ master, add-codedeploy ]
-    types:
-      - completed
+  push:
+      branches: [ add-codedeploy ]
+
+# on:
+#   workflow_run:
+#     workflows: [ "Build and Test C-3PO" ]
+#     branches: [ master, add-codedeploy ]
+#     types:
+#       - completed
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy C-3PO to Amazon ECS
 on:
   workflow_run:
     workflows: [ "Build and Test C-3PO" ]
-    branches: [ master, add-codedeploy ]
+    branches: [ master ]
     types:
       - completed
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,16 +1,11 @@
 name: Deploy C-3PO to Amazon ECS
 
-# Temporary code. To be removed
 on:
-  push:
-      branches: [ add-codedeploy ]
-
-# on:
-#   workflow_run:
-#     workflows: [ "Build and Test C-3PO" ]
-#     branches: [ master, add-codedeploy ]
-#     types:
-#       - completed
+  workflow_run:
+    workflows: [ "Build and Test C-3PO" ]
+    branches: [ master, add-codedeploy ]
+    types:
+      - completed
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy C-3PO to Amazon ECS
 on:
   workflow_run:
     workflows: [ "Build and Test C-3PO" ]
-    branches: [ master ]
+    branches: [ master, add-codedeploy ]
     types:
       - completed
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,21 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ' 3.7'
+  
+    - name: Cache Python Dependencies
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+          ${{ runner.os }}-
+
     - name: Install dependencies
       run: |
         pip install --upgrade pip
         pip install -r requirements/common.txt
         pip install -r requirements/dev.txt
+    
+    - name: Test
+      run: sh ./bin/sanity.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Build and Test C-3PO
 
 on:
     push:
-        branches: [ master, add-codedeploy]
+        branches: [ master ]
     pull_request:
-        branches: [ master, add-codedeploy ]
+        branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Build and Test
+name: Build and Test C-3PO
 
 on:
     push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,21 +2,24 @@ name: Build and Test C-3PO
 
 on:
     push:
-        branches: [ master ]
+        branches: [ master, add-codedeploy]
     pull_request:
-        branches: [ master ]
+        branches: [ master, add-codedeploy ]
 
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.7
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
-        python-version: ' 3.7'
+        python-version: ${{ matrix.python-version }}
   
     - name: Cache Python Dependencies
       uses: actions/cache@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Build and Test
+
+on:
+    push:
+        branches: [ master ]
+    pull_request:
+        branches: [ master ]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: ' 3.7'
+    - name: Install dependencies
+      run: |
+        pip install --upgrade pip
+        pip install -r requirements/common.txt
+        pip install -r requirements/dev.txt

--- a/bin/sanity.sh
+++ b/bin/sanity.sh
@@ -1,4 +1,4 @@
 dodgy
-isort --atomic ./
+isort --atomic ./ --skip migrations
 pydocstyle --config=./config.ini
 pycodestyle ./ --config=./config.ini

--- a/bin/sanity.sh
+++ b/bin/sanity.sh
@@ -1,0 +1,4 @@
+dodgy
+isort --atomic ./
+pydocstyle --config=./config.ini
+pycodestyle ./ --config=./config.ini

--- a/c3po/api/service/feed_service.py
+++ b/c3po/api/service/feed_service.py
@@ -4,12 +4,12 @@ from logging import getLogger
 
 from c3po.api.dto import artist_dto, post_dto, song_dto
 from c3po.api.service.paginate import get_paginated_response
+from c3po.config.config import read_config
 from c3po.db.base import session_factory, session_scope
 from c3po.db.models.artist import ArtistGenre, ArtistSong
 from c3po.db.models.link import Link
 from c3po.db.models.song import Song
 from c3po.db.models.user import UserPosts
-from c3po.config.config import read_config
 
 LOG = getLogger(__name__)
 

--- a/c3po/db/base.py
+++ b/c3po/db/base.py
@@ -1,6 +1,6 @@
+import os
 from contextlib import contextmanager
 from urllib.parse import quote_plus
-import os
 
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base

--- a/c3po/db/metadata.py
+++ b/c3po/db/metadata.py
@@ -6,18 +6,8 @@ from isodate import ISO8601Error, parse_datetime
 from music_metadata_extractor import SongData
 
 from c3po.db.base import session_scope
-from c3po.db.models import (
-    Artist,
-    ArtistGenre,
-    ArtistSong,
-    Genre,
-    Link,
-    Song,
-    SongGenre,
-    User,
-    UserLikes,
-    UserPosts,
-)
+from c3po.db.models import (Artist, ArtistGenre, ArtistSong, Genre, Link, Song,
+                            SongGenre, User, UserLikes, UserPosts)
 
 
 def insert_metadata(raw_data):
@@ -84,7 +74,7 @@ def _insert_post(url, user, extras, raw_data, session):
     else:
         if(likes_count != existing_post.likes_count):
             existing_post.likes_count = likes_count
-            return None         
+            return None
 
 
 def _insert_artist_song(new_artist, new_song, session):

--- a/c3po/db/models/song.py
+++ b/c3po/db/models/song.py
@@ -1,4 +1,5 @@
-from sqlalchemy import Boolean, Column, Date, Float, ForeignKey, Integer, String
+from sqlalchemy import (Boolean, Column, Date, Float, ForeignKey, Integer,
+                        String)
 from sqlalchemy.orm import backref, relationship
 
 from c3po.db.base import Base

--- a/config.ini
+++ b/config.ini
@@ -17,3 +17,14 @@ die-on-term = true
 [api]
 MAX_UNDERRATED_CUSTOM_POPULARITY=0.5
 MAX_UNDERRATED_VIEWS=2000000
+
+[pycodestyle]
+count = True
+ignore = D100, D103, W504
+max-line-length = 120
+exclude=migrations, env
+
+[pydocstyle]
+convention=numpy
+add-ignore=D401 
+match-dir="^(?!migrations).*"

--- a/deploy/c3po-taskdef.json
+++ b/deploy/c3po-taskdef.json
@@ -1,0 +1,162 @@
+{
+  "ipcMode": null,
+  "executionRoleArn": "arn:aws:iam::848472830311:role/AWSTaskRoleForECS",
+  "containerDefinitions": [
+    {
+      "dnsSearchDomains": null,
+      "environmentFiles": null,
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "secretOptions": null,
+        "options": {
+          "awslogs-group": "/ecs/c3po-taskdef",
+          "awslogs-region": "ap-south-1",
+          "awslogs-stream-prefix": "ecs"
+        }
+      },
+      "entryPoint": null,
+      "portMappings": [
+        {
+          "hostPort": 8000,
+          "protocol": "tcp",
+          "containerPort": 8000
+        }
+      ],
+      "command": null,
+      "linuxParameters": null,
+      "cpu": 512,
+      "environment": [],
+      "resourceRequirements": null,
+      "ulimits": null,
+      "dnsServers": null,
+      "mountPoints": [],
+      "workingDirectory": null,
+      "secrets": [
+        {
+          "valueFrom": "arn:aws:secretsmanager:ap-south-1:848472830311:secret:GOOGLE_APPLICATION_CREDENTIALS-2Vfxxs",
+          "name": "GOOGLE_APPLICATION_CREDENTIALS"
+        },
+        {
+          "valueFrom": "arn:aws:secretsmanager:ap-south-1:848472830311:secret:POSTGRES_URI-hVBEcw",
+          "name": "POSTGRES_URI"
+        },
+        {
+          "valueFrom": "arn:aws:secretsmanager:ap-south-1:848472830311:secret:SPOTIFY_REDIRECT_URI-Iy9mbt",
+          "name": "SPOTIFY_REDIRECT_URI"
+        },
+        {
+          "valueFrom": "arn:aws:secretsmanager:ap-south-1:848472830311:secret:SPOTIPY_CLIENT_ID-k3Igtf",
+          "name": "SPOTIPY_CLIENT_ID"
+        },
+        {
+          "valueFrom": "arn:aws:secretsmanager:ap-south-1:848472830311:secret:SPOTIPY_CLIENT_SECRET-pSc1p0",
+          "name": "SPOTIPY_CLIENT_SECRET"
+        },
+        {
+          "valueFrom": "arn:aws:secretsmanager:ap-south-1:848472830311:secret:WHOAMI-HS4gPo",
+          "name": "WHOAMI"
+        }
+      ],
+      "dockerSecurityOptions": null,
+      "memory": null,
+      "memoryReservation": 1024,
+      "volumesFrom": [],
+      "stopTimeout": null,
+      "image": "848472830311.dkr.ecr.ap-south-1.amazonaws.com/c3po:latest",
+      "startTimeout": null,
+      "firelensConfiguration": null,
+      "dependsOn": null,
+      "disableNetworking": null,
+      "interactive": null,
+      "healthCheck": null,
+      "essential": true,
+      "links": null,
+      "hostname": null,
+      "extraHosts": null,
+      "pseudoTerminal": null,
+      "user": null,
+      "readonlyRootFilesystem": null,
+      "dockerLabels": null,
+      "systemControls": null,
+      "privileged": null,
+      "name": "c3po-container"
+    }
+  ],
+  "placementConstraints": [],
+  "memory": "1024",
+  "taskRoleArn": "arn:aws:iam::848472830311:role/AWSTaskRoleForECS",
+  "compatibilities": ["EC2", "FARGATE"],
+  "taskDefinitionArn": "arn:aws:ecs:ap-south-1:848472830311:task-definition/c3po-taskdef:6",
+  "family": "c3po-taskdef",
+  "requiresAttributes": [
+    {
+      "targetId": null,
+      "targetType": null,
+      "value": null,
+      "name": "com.amazonaws.ecs.capability.logging-driver.awslogs"
+    },
+    {
+      "targetId": null,
+      "targetType": null,
+      "value": null,
+      "name": "ecs.capability.execution-role-awslogs"
+    },
+    {
+      "targetId": null,
+      "targetType": null,
+      "value": null,
+      "name": "com.amazonaws.ecs.capability.ecr-auth"
+    },
+    {
+      "targetId": null,
+      "targetType": null,
+      "value": null,
+      "name": "com.amazonaws.ecs.capability.docker-remote-api.1.19"
+    },
+    {
+      "targetId": null,
+      "targetType": null,
+      "value": null,
+      "name": "ecs.capability.secrets.asm.environment-variables"
+    },
+    {
+      "targetId": null,
+      "targetType": null,
+      "value": null,
+      "name": "com.amazonaws.ecs.capability.docker-remote-api.1.21"
+    },
+    {
+      "targetId": null,
+      "targetType": null,
+      "value": null,
+      "name": "com.amazonaws.ecs.capability.task-iam-role"
+    },
+    {
+      "targetId": null,
+      "targetType": null,
+      "value": null,
+      "name": "ecs.capability.execution-role-ecr-pull"
+    },
+    {
+      "targetId": null,
+      "targetType": null,
+      "value": null,
+      "name": "com.amazonaws.ecs.capability.docker-remote-api.1.18"
+    },
+    {
+      "targetId": null,
+      "targetType": null,
+      "value": null,
+      "name": "ecs.capability.task-eni"
+    }
+  ],
+  "pidMode": null,
+  "requiresCompatibilities": ["FARGATE"],
+  "networkMode": "awsvpc",
+  "cpu": "512",
+  "revision": 6,
+  "status": "ACTIVE",
+  "inferenceAccelerators": null,
+  "proxyConfiguration": null,
+  "volumes": []
+}

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,5 +1,6 @@
 """WSGI Server file."""
-from dotenv import load_dotenv, find_dotenv
+from dotenv import find_dotenv, load_dotenv
+
 from c3po.manage import app
 
 load_dotenv(find_dotenv())


### PR DESCRIPTION
This PR adds CodeDeploy to the project. There are essentially 2 parts in the process:

- [x] Add GitHub Actions to test code pushes/PRs on master

- [x] Setup GitHub  Actions to auto-deploy to ECS using the correct task definition

- [x] Setup Secrets Manager on AWS to allow ECS task definition to pickup secrets from the `valueFrom` property 

For now, I've added a basic `test.yml` that will just install dependencies and run the script `bin/sanity.sh` to test if the code conforms to the guidelines specified in `config.ini`