### PR TITLE
Minor GitHub Actions bug fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('requirements/common.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-
           ${{ runner.os }}-

--- a/deploy/c3po-taskdef.json
+++ b/deploy/c3po-taskdef.json
@@ -25,7 +25,16 @@
       "command": null,
       "linuxParameters": null,
       "cpu": 512,
-      "environment": [],
+      "environment": [
+        {
+          "name": "SPOTIFY_REDIRECT_URI",
+          "value": "http://localhost:5000"
+        },
+        {
+          "name": "SPOTIPY_CLIENT_ID",
+          "value": "e02422b74f7c4179b3c3c8e3acb6c4fa"
+        }
+      ],
       "resourceRequirements": null,
       "ulimits": null,
       "dnsServers": null,
@@ -39,14 +48,6 @@
         {
           "valueFrom": "arn:aws:secretsmanager:ap-south-1:848472830311:secret:POSTGRES_URI-hVBEcw",
           "name": "POSTGRES_URI"
-        },
-        {
-          "valueFrom": "arn:aws:secretsmanager:ap-south-1:848472830311:secret:SPOTIFY_REDIRECT_URI-Iy9mbt",
-          "name": "SPOTIFY_REDIRECT_URI"
-        },
-        {
-          "valueFrom": "arn:aws:secretsmanager:ap-south-1:848472830311:secret:SPOTIPY_CLIENT_ID-k3Igtf",
-          "name": "SPOTIPY_CLIENT_ID"
         },
         {
           "valueFrom": "arn:aws:secretsmanager:ap-south-1:848472830311:secret:SPOTIPY_CLIENT_SECRET-pSc1p0",
@@ -85,77 +86,11 @@
   "placementConstraints": [],
   "memory": "1024",
   "taskRoleArn": "arn:aws:iam::848472830311:role/AWSTaskRoleForECS",
-  "compatibilities": ["EC2", "FARGATE"],
-  "taskDefinitionArn": "arn:aws:ecs:ap-south-1:848472830311:task-definition/c3po-taskdef:6",
   "family": "c3po-taskdef",
-  "requiresAttributes": [
-    {
-      "targetId": null,
-      "targetType": null,
-      "value": null,
-      "name": "com.amazonaws.ecs.capability.logging-driver.awslogs"
-    },
-    {
-      "targetId": null,
-      "targetType": null,
-      "value": null,
-      "name": "ecs.capability.execution-role-awslogs"
-    },
-    {
-      "targetId": null,
-      "targetType": null,
-      "value": null,
-      "name": "com.amazonaws.ecs.capability.ecr-auth"
-    },
-    {
-      "targetId": null,
-      "targetType": null,
-      "value": null,
-      "name": "com.amazonaws.ecs.capability.docker-remote-api.1.19"
-    },
-    {
-      "targetId": null,
-      "targetType": null,
-      "value": null,
-      "name": "ecs.capability.secrets.asm.environment-variables"
-    },
-    {
-      "targetId": null,
-      "targetType": null,
-      "value": null,
-      "name": "com.amazonaws.ecs.capability.docker-remote-api.1.21"
-    },
-    {
-      "targetId": null,
-      "targetType": null,
-      "value": null,
-      "name": "com.amazonaws.ecs.capability.task-iam-role"
-    },
-    {
-      "targetId": null,
-      "targetType": null,
-      "value": null,
-      "name": "ecs.capability.execution-role-ecr-pull"
-    },
-    {
-      "targetId": null,
-      "targetType": null,
-      "value": null,
-      "name": "com.amazonaws.ecs.capability.docker-remote-api.1.18"
-    },
-    {
-      "targetId": null,
-      "targetType": null,
-      "value": null,
-      "name": "ecs.capability.task-eni"
-    }
-  ],
   "pidMode": null,
   "requiresCompatibilities": ["FARGATE"],
   "networkMode": "awsvpc",
   "cpu": "512",
-  "revision": 6,
-  "status": "ACTIVE",
   "inferenceAccelerators": null,
   "proxyConfiguration": null,
   "volumes": []


### PR DESCRIPTION
Fixes #86 and #87 

- Fix path of requirements file when caching dependencies
- Remote `SPOTIFY_REDIRECT_URI` and `SPOTIPY_CLIENT_ID` from secrets and move them to environment variables