### PR TITLE
Add endpoint to check status of posts (active or stale)

### DIFF
--- a/c3po/api/controller/health_controller.py
+++ b/c3po/api/controller/health_controller.py
@@ -15,6 +15,7 @@ class HealthCheck(Resource):
     def get(self):
         return {"success": True}, 200
 
+
 @health_ns.route("/status")
 class StatusCheck(Resource):
     """ Check if posts are active or stale """

--- a/c3po/api/controller/health_controller.py
+++ b/c3po/api/controller/health_controller.py
@@ -2,6 +2,7 @@ from flask import abort, request
 from flask_restx import Namespace, Resource, reqparse
 
 from c3po.api.dto import HealthDto
+from c3po.api.service.health_service import get_active_status
 
 health_ns = HealthDto.ns
 
@@ -13,3 +14,11 @@ class HealthCheck(Resource):
     @health_ns.doc("Check API health")
     def get(self):
         return {"success": True}, 200
+
+@health_ns.route("/status")
+class StatusCheck(Resource):
+    """ Check if posts are active or stale """
+    def get(self):
+        if get_active_status():
+            return {"status": "Active"}, 200
+        return {"status": "Stale"}, 200

--- a/c3po/api/service/health_service.py
+++ b/c3po/api/service/health_service.py
@@ -7,6 +7,7 @@ from c3po.config.config import read_config
 LOG = getLogger(__name__)
 MAX_ACTIVE_DAYS = read_config(section="api")["MAX_ACTIVE_DAYS"]
 
+
 def get_active_status():
     """ Checks the share_date of the latest post. """
     with session_scope() as session:
@@ -17,7 +18,7 @@ def get_active_status():
             .all()
         )
         latest_post = posts[0]
-        print(type(MAX_ACTIVE_DAYS))
-        if datetime.now() - latest_post.share_date <= timedelta(days=int(MAX_ACTIVE_DAYS)):
+        if datetime.now() - latest_post.share_date <= timedelta(
+                days=int(MAX_ACTIVE_DAYS)):
             return True
         return False

--- a/c3po/api/service/health_service.py
+++ b/c3po/api/service/health_service.py
@@ -1,0 +1,22 @@
+from logging import getLogger
+from c3po.db.models.user import UserPosts
+from c3po.db.base import session_scope
+from datetime import datetime, timedelta
+from c3po.config.config import read_config
+
+LOG = getLogger(__name__)
+MAX_ACTIVE_DAYS = read_config(section="api")["MAX_ACTIVE_DAYS"]
+
+def get_active_status():
+    """ Checks the share_date of the latest post. """
+    with session_scope() as session:
+        posts = (
+            session.query(UserPosts)
+            .order_by(UserPosts.share_date.desc)
+            .limit(1)
+            .all()
+        )
+        latest_post = posts[0]
+        if datetime.now() - latest_post.share_date <= timedelta(days=MAX_ACTIVE_DAYS):
+            return True
+        return False

--- a/c3po/api/service/health_service.py
+++ b/c3po/api/service/health_service.py
@@ -12,11 +12,12 @@ def get_active_status():
     with session_scope() as session:
         posts = (
             session.query(UserPosts)
-            .order_by(UserPosts.share_date.desc)
+            .order_by(UserPosts.share_date.desc())
             .limit(1)
             .all()
         )
         latest_post = posts[0]
-        if datetime.now() - latest_post.share_date <= timedelta(days=MAX_ACTIVE_DAYS):
+        print(type(MAX_ACTIVE_DAYS))
+        if datetime.now() - latest_post.share_date <= timedelta(days=int(MAX_ACTIVE_DAYS)):
             return True
         return False

--- a/config.ini
+++ b/config.ini
@@ -17,6 +17,7 @@ die-on-term = true
 [api]
 MAX_UNDERRATED_CUSTOM_POPULARITY=0.5
 MAX_UNDERRATED_VIEWS=2000000
+MAX_ACTIVE_DAYS=2
 
 [pycodestyle]
 count = True

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -8,7 +8,7 @@ flask_restx==0.2.0
 Flask==1.1.2
 isodate==0.6.0
 coloredlogs==14.0
-httplib2==0.18.1
+httplib2==0.19.0
 Flask_Cors==3.0.8
 psycopg2==2.8.5
 psycopg2-binary==2.8.5


### PR DESCRIPTION
As requested by @xypnox, this is an endpoint that can be used to determine if posts are stale. The endpoint will return a "Stale" status if the latest post in the DB is more than 2 days old. we can change this in the config. It will return "Active" otherwise.
@mukul-mehta can you please test this on your machine? I haven't figured out the issues in docker yet :sweat_smile: 