### PR TITLE
Reduce C-3PO docker container size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,24 @@
 # Base Python image for container
-FROM python:3.7-slim
+FROM python:3.7-slim AS builder
 RUN apt-get update \
     && apt-get install gcc -y \
     && apt-get clean
+
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+COPY requirements/common.txt requirements.txt
+RUN pip install --upgrade pip && pip install --no-cache-dir -r requirements.txt
+
+
+FROM python:3.7-slim
 
 # Set unbuffered output to make sure all logs are printed and not stuck in buffer
 ENV PYTHONUNBUFFERED 1
 
 RUN mkdir -p /c3po
-
-# Copy and install requirements
-ADD requirements /c3po/requirements
-RUN pip install --upgrade pip
-RUN pip install --no-cache-dir -r /c3po/requirements/common.txt && pip install --no-cache-dir -r /c3po/requirements/dev.txt
+COPY --from=builder /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
 
 ADD . /c3po/
 WORKDIR /c3po

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,18 @@
 # Base Python image for container
-FROM python:3.7
+FROM python:3.7-slim
+RUN apt-get update \
+    && apt-get install gcc -y \
+    && apt-get clean
 
 # Set unbuffered output to make sure all logs are printed and not stuck in buffer
 ENV PYTHONUNBUFFERED 1
 
-RUN apt-get update
 RUN mkdir -p /c3po
 
 # Copy and install requirements
 ADD requirements /c3po/requirements
 RUN pip install --upgrade pip
-RUN pip install -r /c3po/requirements/common.txt && pip install -r /c3po/requirements/dev.txt
+RUN pip install --no-cache-dir -r /c3po/requirements/common.txt && pip install --no-cache-dir -r /c3po/requirements/dev.txt
 
 ADD . /c3po/
 WORKDIR /c3po

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -10,6 +10,6 @@ isodate==0.6.0
 coloredlogs==14.0
 httplib2==0.19.0
 Flask_Cors==3.0.8
-psycopg2==2.8.5
+#psycopg2==2.8.5
 psycopg2-binary==2.8.5
 python-dotenv==0.14.0


### PR DESCRIPTION
The present `Dockerfile` uses `python:3.7` as a base image, which comes with a full blown set of utilities, most of which we do not need. We could switch to the slim version of the image, which is considerably smaller in size, and fully compatible with our existing setup (slim is also based on debian). Also, we could switch to multistage builds, with 2 stages - one to install all dependencies via `apt` and `pip`, and the second image which runs the actual application.

This PR switched to `python:3.7-slim` and uses 2 stage builds